### PR TITLE
Refactor geometry helpers into shared module

### DIFF
--- a/common/geometry.py
+++ b/common/geometry.py
@@ -1,0 +1,77 @@
+"""
+Common geometry utilities for Stealth Golf.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple, Optional
+
+
+def clamp(v: float, lo: float, hi: float) -> float:
+    """Clamp *v* to the inclusive range [lo, hi]."""
+    return lo if v < lo else hi if v > hi else v
+
+
+def length(vx: float, vy: float) -> float:
+    """Return the Euclidean length of a 2-D vector."""
+    return (vx * vx + vy * vy) ** 0.5
+
+
+def normalize(vx: float, vy: float) -> Tuple[float, float]:
+    """Return the unit vector of (vx, vy) or (0, 0) if zero length."""
+    l = length(vx, vy)
+    return (0.0, 0.0) if l == 0 else (vx / l, vy / l)
+
+
+def seg_intersect(p1: Tuple[float, float], p2: Tuple[float, float],
+                  p3: Tuple[float, float], p4: Tuple[float, float]) -> Tuple[bool, float, float, float, float]:
+    """Return intersection data for segment p1-p2 with segment p3-p4."""
+    x1, y1 = p1; x2, y2 = p2; x3, y3 = p3; x4, y4 = p4
+    den = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
+    if abs(den) < 1e-9:
+        return (False, 0, 0, 0, 0)
+    t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / den
+    u = ((x1 - x3) * (y1 - y2) - (y1 - y3) * (x1 - x2)) / den
+    if 0 <= t <= 1 and 0 <= u <= 1:
+        ix = x1 + t * (x2 - x1); iy = y1 + t * (y2 - y1)
+        return (True, t, u, ix, iy)
+    return (False, 0, 0, 0, 0)
+
+
+def ray_rect_nearest_hit(ox: float, oy: float, dirx: float, diry: float,
+                         rect: Tuple[float, float, float, float]) -> Optional[Tuple[float, float]]:
+    """Return nearest hit point of a ray and axis-aligned rectangle or ``None``."""
+    rx, ry, rw, rh = rect
+    farx = ox + dirx * 99999
+    fary = oy + diry * 99999
+    best_t = None
+    best_pt = None
+    edges = [
+        ((rx, ry), (rx + rw, ry)),
+        ((rx + rw, ry), (rx + rw, ry + rh)),
+        ((rx + rw, ry + rh), (rx, ry + rh)),
+        ((rx, ry + rh), (rx, ry)),
+    ]
+    for a, b in edges:
+        hit, t, u, ix, iy = seg_intersect((ox, oy), (farx, fary), a, b)
+        if hit and (best_t is None or t < best_t):
+            best_t = t
+            best_pt = (ix, iy)
+    return best_pt
+
+
+def los_blocked(ox: float, oy: float, tx: float, ty: float,
+                walls: Iterable[Tuple[float, float, float, float]]) -> bool:
+    """Return ``True`` if line of sight from (ox, oy) to (tx, ty) is blocked."""
+    for rx, ry, rw, rh in walls:
+        edges = [
+            ((rx, ry), (rx + rw, ry)),
+            ((rx + rw, ry), (rx + rw, ry + rh)),
+            ((rx + rw, ry + rh), (rx, ry + rh)),
+            ((rx, ry + rh), (rx, ry)),
+        ]
+        for a, b in edges:
+            hit, t, u, ix, iy = seg_intersect((ox, oy), (tx, ty), a, b)
+            if hit and 0 < t < 1 - 1e-6:
+                return True
+    return False

--- a/stealth_golf_kivy_loadlevel.py
+++ b/stealth_golf_kivy_loadlevel.py
@@ -10,6 +10,14 @@ from kivy.core.window import Window
 from kivy.graphics import Color, Ellipse, Rectangle, Line, Triangle, PushMatrix, PopMatrix, Translate, Mesh
 from kivy.uix.widget import Widget
 from kivy.uix.label import Label
+from common.geometry import (
+    clamp,
+    length,
+    normalize,
+    seg_intersect,
+    ray_rect_nearest_hit,
+    los_blocked,
+)
 
 LEVEL_PATH = "level.json"  # change to your file name if desired
 
@@ -17,55 +25,6 @@ try:
     Window.size = (480, 800)
 except Exception:
     pass
-
-def clamp(v, lo, hi): return lo if v < lo else hi if v > hi else v
-def length(vx, vy): return (vx*vx + vy*vy) ** 0.5
-def normalize(vx, vy):
-    l = length(vx, vy); 
-    return (0.0, 0.0) if l==0 else (vx/l, vy/l)
-
-def seg_intersect(p1, p2, p3, p4):
-    x1,y1 = p1; x2,y2 = p2; x3,y3 = p3; x4,y4 = p4
-    den = (x1-x2)*(y3-y4) - (y1-y2)*(x3-x4)
-    if abs(den) < 1e-9: return (False, 0, 0, 0, 0)
-    t = ((x1-x3)*(y3-y4) - (y1-y3)*(x3-x4)) / den
-    u = ((x1-x3)*(y1-y2) - (y1-y3)*(x1-x2)) / den
-    if 0 <= t <= 1 and 0 <= u <= 1:
-        ix = x1 + t*(x2-x1); iy = y1 + t*(y2-y1)
-        return (True, t, u, ix, iy)
-    return (False, 0, 0, 0, 0)
-
-def ray_rect_nearest_hit(ox, oy, dirx, diry, rect):
-    rx, ry, rw, rh = rect
-    farx = ox + dirx * 99999
-    fary = oy + diry * 99999
-    best_t = None
-    best_pt = None
-    edges = [
-        ((rx, ry), (rx+rw, ry)),
-        ((rx+rw, ry), (rx+rw, ry+rh)),
-        ((rx+rw, ry+rh), (rx, ry+rh)),
-        ((rx, ry+rh), (rx, ry)),
-    ]
-    for a,b in edges:
-        hit, t, u, ix, iy = seg_intersect((ox,oy), (farx,fary), a, b)
-        if hit and (best_t is None or t < best_t):
-            best_t = t; best_pt = (ix, iy)
-    return best_pt
-
-def los_blocked(ox, oy, tx, ty, walls):
-    for rx, ry, rw, rh in walls:
-        edges = [
-            ((rx, ry), (rx+rw, ry)),
-            ((rx+rw, ry), (rx+rw, ry+rh)),
-            ((rx+rw, ry+rh), (rx, ry+rh)),
-            ((rx, ry+rh), (rx, ry)),
-        ]
-        for a,b in edges:
-            hit, t, u, ix, iy = seg_intersect((ox,oy), (tx,ty), a, b)
-            if hit and 0 < t < 1 - 1e-6:
-                return True
-    return False
 
 class Ball:
     def __init__(self, x, y, r=14):

--- a/stealth_golf_kivy_loadlevel_fixed.py
+++ b/stealth_golf_kivy_loadlevel_fixed.py
@@ -11,6 +11,14 @@ from kivy.core.window import Window
 from kivy.graphics import Color, Ellipse, Rectangle, Line, Triangle, PushMatrix, PopMatrix, Translate, Mesh
 from kivy.uix.widget import Widget
 from kivy.uix.label import Label
+from common.geometry import (
+    clamp,
+    length,
+    normalize,
+    seg_intersect,
+    ray_rect_nearest_hit,
+    los_blocked,
+)
 
 # Try not to crash if Window isn't available (e.g., packaging env)
 try:
@@ -28,54 +36,6 @@ LOW_SPEED_DAMP_BASE = 0.78   # stronger damping baseline when very slow (per 60 
 LOW_SPEED_DAMP_NEAR = 0.92   # gentler damping near threshold (per 60 FPS frame)
 
 # -------------------------------- Utilities ----------------------------------
-def clamp(v, lo, hi): return lo if v < lo else hi if v > hi else v
-def length(vx, vy): return (vx*vx + vy*vy) ** 0.5
-def normalize(vx, vy):
-    l = length(vx, vy)
-    return (0.0, 0.0) if l==0 else (vx/l, vy/l)
-
-def seg_intersect(p1, p2, p3, p4):
-    x1,y1 = p1; x2,y2 = p2; x3,y3 = p3; x4,y4 = p4
-    den = (x1-x2)*(y3-y4) - (y1-y2)*(x3-x4)
-    if abs(den) < 1e-9: return (False, 0, 0, 0, 0)
-    t = ((x1-x3)*(y3-y4) - (y1-y3)*(x3-x4)) / den
-    u = ((x1-x3)*(y1-y2) - (y1-y3)*(x1-x2)) / den
-    if 0 <= t <= 1 and 0 <= u <= 1:
-        ix = x1 + t*(x2-x1); iy = y1 + t*(y2-y1)
-        return (True, t, u, ix, iy)
-    return (False, 0, 0, 0, 0)
-
-def ray_rect_nearest_hit(ox, oy, dirx, diry, rect):
-    rx, ry, rw, rh = rect
-    farx = ox + dirx * 99999
-    fary = oy + diry * 99999
-    best_t = None
-    best_pt = None
-    edges = [
-        ((rx, ry), (rx+rw, ry)),
-        ((rx+rw, ry), (rx+rw, ry+rh)),
-        ((rx+rw, ry+rh), (rx, ry+rh)),
-        ((rx, ry+rh), (rx, ry)),
-    ]
-    for a,b in edges:
-        hit, t, u, ix, iy = seg_intersect((ox,oy), (farx,fary), a, b)
-        if hit and (best_t is None or t < best_t):
-            best_t = t; best_pt = (ix, iy)
-    return best_pt
-
-def los_blocked(ox, oy, tx, ty, walls):
-    for rx, ry, rw, rh in walls:
-        edges = [
-            ((rx, ry), (rx+rw, ry)),
-            ((rx+rw, ry), (rx+rw, ry+rh)),
-            ((rx+rw, ry+rh), (rx, ry+rh)),
-            ((rx, ry+rh), (rx, ry)),
-        ]
-        for a,b in edges:
-            hit, t, u, ix, iy = seg_intersect((ox,oy), (tx,ty), a, b)
-            if hit and 0 < t < 1 - 1e-6:
-                return True
-    return False
 
 def _search_paths(names):
     # search CWD and script dir

--- a/stealth_golf_level_editor.py
+++ b/stealth_golf_level_editor.py
@@ -15,6 +15,7 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.button import Button
 from kivy.uix.label import Label
 from kivy.uix.floatlayout import FloatLayout
+from common.geometry import length, normalize, seg_intersect, ray_rect_nearest_hit
 
 try:
     Window.size = (900, 1000)  # larger editor window
@@ -24,39 +25,6 @@ except Exception:
 GRID = 20
 
 def snap(v): return int(round(v / GRID)) * GRID
-def length(vx, vy): return (vx*vx + vy*vy)**0.5
-def normalize(vx, vy):
-    l = length(vx, vy)
-    return (0.0, 0.0) if l == 0 else (vx/l, vy/l)
-
-def seg_intersect(p1, p2, p3, p4):
-    x1,y1 = p1; x2,y2 = p2; x3,y3 = p3; x4,y4 = p4
-    den = (x1-x2)*(y3-y4) - (y1-y2)*(x3-x4)
-    if abs(den) < 1e-9: return (False, 0, 0, 0, 0)
-    t = ((x1-x3)*(y3-y4) - (y1-y3)*(x3-x4)) / den
-    u = ((x1-x3)*(y1-y2) - (y1-y3)*(x1-x2)) / den
-    if 0 <= t <= 1 and 0 <= u <= 1:
-        ix = x1 + t*(x2-x1); iy = y1 + t*(y2-y1)
-        return (True, t, u, ix, iy)
-    return (False, 0, 0, 0, 0)
-
-def ray_rect_nearest_hit(ox, oy, dirx, diry, rect):
-    rx, ry, rw, rh = rect
-    farx = ox + dirx * 99999
-    fary = oy + diry * 99999
-    best_t = None
-    best_pt = None
-    edges = [
-        ((rx, ry), (rx+rw, ry)),
-        ((rx+rw, ry), (rx+rw, ry+rh)),
-        ((rx+rw, ry+rh), (rx, ry+rh)),
-        ((rx, ry+rh), (rx, ry)),
-    ]
-    for a,b in edges:
-        hit, t, u, ix, iy = seg_intersect((ox,oy), (farx,fary), a, b)
-        if hit and (best_t is None or t < best_t):
-            best_t = t; best_pt = (ix, iy)
-    return best_pt
 
 class LevelCanvas(Widget):
     def __init__(self, **kwargs):


### PR DESCRIPTION
## Summary
- add `common.geometry` module with reusable geometry functions
- import shared helpers in Kivy loader and level editor, removing duplicated code

## Testing
- `python -m py_compile common/geometry.py stealth_golf_kivy_loadlevel.py stealth_golf_kivy_loadlevel_fixed.py stealth_golf_level_editor.py`
- `rg seg_intersect -n`


------
https://chatgpt.com/codex/tasks/task_e_689e130a80748329b3ee8582048fa178