### PR TITLE
Delay floor switch until stair midpoint

### DIFF
--- a/stealth_golf.py
+++ b/stealth_golf.py
@@ -608,8 +608,17 @@ class StealthGolf(Widget):
                         rx, ry, rw, rh = s["rect"]
                         if rx <= self.ball.x <= rx + rw and ry <= self.ball.y <= ry + rh:
                             currently_on_stairs = True
-                            if not self.on_stairs and self.transition_cooldown <= 0:
-                                target = s.get("target", self.current_floor + (1 if s["dir"] == "up" else -1))
+                            midpoint = ry + rh * 0.5
+                            crossed_mid = (
+                                self.ball.y >= midpoint
+                                if s.get("dir", "up") == "up"
+                                else self.ball.y <= midpoint
+                            )
+                            if crossed_mid and not self.on_stairs and self.transition_cooldown <= 0:
+                                target = s.get(
+                                    "target",
+                                    self.current_floor + (1 if s.get("dir", "up") == "up" else -1),
+                                )
                                 if 0 <= target < len(self.floors):
                                     self.prev_walls = list(self.walls_drawn)
                                     self.prev_decor = list(self.decor)


### PR DESCRIPTION
## Summary
- Update staircase logic to change floors only after the ball crosses the stair's midpoint

## Testing
- `python -m py_compile stealth_golf.py stealth_golf_level_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_689f8e567ce083298c1aa50dad4f741f