### PR TITLE
Add door placement workflow with color picker

### DIFF
--- a/door_example.json
+++ b/door_example.json
@@ -1,0 +1,18 @@
+{
+  "world": {"w": 1400, "h": 2200},
+  "start": [240,220],
+  "start_floor": 0,
+  "hole": {"cx":1240, "cy":2020, "r":22},
+  "hole_floor": 0,
+  "floors": [
+    {
+      "walls": [],
+      "decor": [],
+      "agents": [],
+      "stairs": [],
+      "doors": [
+        {"rect": [100,100,80,20], "screen": [200,200,60,40], "color": "red"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- support doors in level data and JSON I/O
- add door tool with color picker and two-step placement
- draw and erase doors along with existing elements

## Testing
- `python -m py_compile stealth_golf_level_editor.py`
- `python -m json.tool door_example.json >/tmp/door_tmp.json`


------
https://chatgpt.com/codex/tasks/task_e_689f9c29ace88329a11d97a0220dcc2e