### PR TITLE
Add scenery dropdown and new decorations

### DIFF
--- a/stealth_golf.py
+++ b/stealth_golf.py
@@ -439,7 +439,10 @@ class StealthGolf(Widget):
 
         # Decor
         self.decor = []
-        collidable = {"plant", "desk", "chair", "table"}
+        collidable = {"plant", "desk", "chair", "table",
+                      "big_red_button", "blue_screen_monitor",
+                      "big_blue_button", "big_green_button",
+                      "big_yellow_button"}
         for d in f.get("decor", []):
             if isinstance(d, dict):
                 kind = d.get("kind", "")
@@ -757,6 +760,21 @@ class StealthGolf(Widget):
             elif kind == "table":
                 Color(0.4, 0.3, 0.2, alpha); Rectangle(pos=(rx, ry), size=(rw, rh))
                 Color(0.3, 0.22, 0.15, alpha); Line(rectangle=(rx, ry, rw, rh), width=1.2)
+            elif kind == "big_red_button":
+                Color(0.4, 0.4, 0.4, alpha); Ellipse(pos=(rx, ry), size=(rw, rh))
+                Color(0.8, 0.0, 0.0, alpha); Ellipse(pos=(rx + rw * 0.1, ry + rh * 0.1), size=(rw * 0.8, rh * 0.8))
+            elif kind == "blue_screen_monitor":
+                Color(0.1, 0.1, 0.1, alpha); Rectangle(pos=(rx, ry), size=(rw, rh))
+                Color(0.2, 0.4, 0.9, alpha); Rectangle(pos=(rx + 5, ry + 5), size=(rw - 10, rh - 10))
+            elif kind == "big_blue_button":
+                Color(0.4, 0.4, 0.4, alpha); Ellipse(pos=(rx, ry), size=(rw, rh))
+                Color(0.0, 0.0, 0.8, alpha); Ellipse(pos=(rx + rw * 0.1, ry + rh * 0.1), size=(rw * 0.8, rh * 0.8))
+            elif kind == "big_green_button":
+                Color(0.4, 0.4, 0.4, alpha); Ellipse(pos=(rx, ry), size=(rw, rh))
+                Color(0.0, 0.6, 0.0, alpha); Ellipse(pos=(rx + rw * 0.1, ry + rh * 0.1), size=(rw * 0.8, rh * 0.8))
+            elif kind == "big_yellow_button":
+                Color(0.4, 0.4, 0.4, alpha); Ellipse(pos=(rx, ry), size=(rw, rh))
+                Color(0.8, 0.8, 0.0, alpha); Ellipse(pos=(rx + rw * 0.1, ry + rh * 0.1), size=(rw * 0.8, rh * 0.8))
             else:
                 col = d.get("color", [0.3, 0.3, 0.35, 1])
                 if len(col) == 3:

--- a/stealth_golf_level_editor.py
+++ b/stealth_golf_level_editor.py
@@ -50,6 +50,23 @@ COLOR_MAP = {
     "brown": (0.55,0.27,0.07),
 }
 
+# Scenery tool names and mapping to stored "kind" strings
+SCENERY_KIND_MAP = {
+    "Elevator": "elevator",
+    "Rug": "rug",
+    "Vent": "vent",
+    "Plant": "plant",
+    "Desk": "desk",
+    "Chair": "chair",
+    "Table": "table",
+    "BigRedButton": "big_red_button",
+    "BlueScreen": "blue_screen_monitor",
+    "BigBlueButton": "big_blue_button",
+    "BigGreenButton": "big_green_button",
+    "BigYellowButton": "big_yellow_button",
+}
+SCENERY_TOOLS = tuple(SCENERY_KIND_MAP.keys())
+
 class LevelCanvas(Widget):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -148,7 +165,7 @@ class LevelCanvas(Widget):
             self.drag_start_world = (touch.x, touch.y, self.cam_x, self.cam_y)
             return True
 
-        if self.tool in ("Wall","Elevator","Rug","Vent","Plant","Desk","Chair","Table","StairUp","StairDown","Door"):
+        if self.tool in ("Wall","StairUp","StairDown","Door") + SCENERY_TOOLS:
             self.dragging = True
             self.temp_rect = (wx, wy, 1, 1)
             return True
@@ -221,26 +238,13 @@ class LevelCanvas(Widget):
         return False
 
     def on_touch_up(self, touch):
-        if self.tool in ("Wall","Elevator","Rug","Vent","Plant","Desk","Chair","Table","StairUp","StairDown","Door") and self.dragging and self.temp_rect:
+        if self.tool in ("Wall","StairUp","StairDown","Door") + SCENERY_TOOLS and self.dragging and self.temp_rect:
             x,y,w,h = self.temp_rect
             if w >= GRID and h >= GRID:
                 if self.tool == "Wall":
                     self.walls.append((x,y,w,h))
-                elif self.tool in ("Elevator","Rug","Vent","Plant","Desk","Chair","Table"):
-                    if self.tool == "Elevator":
-                        kind = "elevator"
-                    elif self.tool == "Rug":
-                        kind = "rug"
-                    elif self.tool == "Vent":
-                        kind = "vent"
-                    elif self.tool == "Plant":
-                        kind = "plant"
-                    elif self.tool == "Desk":
-                        kind = "desk"
-                    elif self.tool == "Chair":
-                        kind = "chair"
-                    else:
-                        kind = "table"
+                elif self.tool in SCENERY_TOOLS:
+                    kind = SCENERY_KIND_MAP.get(self.tool, self.tool.lower())
                     self.decor.append({"kind":kind, "rect":[x,y,w,h]})
                 elif self.tool == "Door":
                     if self.pending_door_rect is None:
@@ -336,6 +340,31 @@ class LevelCanvas(Widget):
                     Rectangle(pos=(rx,ry), size=(rw,rh))
                     Color(0.3,0.22,0.15,1.0)
                     Line(rectangle=(rx,ry,rw,rh), width=1.2)
+                elif kind == "big_red_button":
+                    Color(0.4,0.4,0.4,1.0)
+                    Ellipse(pos=(rx,ry), size=(rw,rh))
+                    Color(0.8,0.0,0.0,1.0)
+                    Ellipse(pos=(rx+rw*0.1, ry+rh*0.1), size=(rw*0.8, rh*0.8))
+                elif kind == "blue_screen_monitor":
+                    Color(0.1,0.1,0.1,1.0)
+                    Rectangle(pos=(rx,ry), size=(rw,rh))
+                    Color(0.2,0.4,0.9,1.0)
+                    Rectangle(pos=(rx+5, ry+5), size=(rw-10, rh-10))
+                elif kind == "big_blue_button":
+                    Color(0.4,0.4,0.4,1.0)
+                    Ellipse(pos=(rx,ry), size=(rw,rh))
+                    Color(0.0,0.0,0.8,1.0)
+                    Ellipse(pos=(rx+rw*0.1, ry+rh*0.1), size=(rw*0.8, rh*0.8))
+                elif kind == "big_green_button":
+                    Color(0.4,0.4,0.4,1.0)
+                    Ellipse(pos=(rx,ry), size=(rw,rh))
+                    Color(0.0,0.6,0.0,1.0)
+                    Ellipse(pos=(rx+rw*0.1, ry+rh*0.1), size=(rw*0.8, rh*0.8))
+                elif kind == "big_yellow_button":
+                    Color(0.4,0.4,0.4,1.0)
+                    Ellipse(pos=(rx,ry), size=(rw,rh))
+                    Color(0.8,0.8,0.0,1.0)
+                    Ellipse(pos=(rx+rw*0.1, ry+rh*0.1), size=(rw*0.8, rh*0.8))
 
             # Doors
             for d in self.doors:
@@ -445,7 +474,7 @@ class LevelCanvas(Widget):
         if not self.status:
             self.status = Label(text="", font_size=14, color=(1,1,1,1), size_hint=(None,None), pos=(10, 8))
             self.add_widget(self.status)
-        self.status.text = f"Floor {floor_label(self.current_floor)}  •  Tool: [b]{self.tool}[/b]  •  Grid: {GRID}px   (Ctrl+S=Save, Ctrl+O=Load, 1..0=Tools, V=Vent, P=Plant, D=Desk, O=Chair, T=Table)"
+        self.status.text = f"Floor {floor_label(self.current_floor)}  •  Tool: [b]{self.tool}[/b]  •  Grid: {GRID}px   (Ctrl+S=Save, Ctrl+O=Load, 1..9=Tools)"
         self.status.markup = True
 
 class LevelEditorRoot(FloatLayout):
@@ -472,9 +501,13 @@ class LevelEditorRoot(FloatLayout):
 
     def _build_toolbar(self):
         self.toolbar.spacing = 4
-        tools = ["Pan","Wall","Door","Agent","Start","Hole","Elevator","Rug","Vent","Plant","Desk","Chair","Table","StairUp","StairDown","Erase"]
+        tools = ["Pan","Wall","Door","Agent","Start","Hole","StairUp","StairDown","Erase"]
         for t in tools:
             self.toolbar.add_widget(self._tool_button(t))
+
+        self.scenery_spinner = Spinner(text="Scenery", values=SCENERY_TOOLS, size_hint=(None,1), width=150)
+        self.scenery_spinner.bind(text=self._on_scenery_select)
+        self.toolbar.add_widget(self.scenery_spinner)
 
         self.toolbar.add_widget(self._tool_button("Save"))
 
@@ -542,21 +575,10 @@ class LevelEditorRoot(FloatLayout):
         # Number keys -> tools
         mapping = {
             '1':"Pan", '2':"Wall", '3':"Agent", '4':"Start",
-            '5':"Hole", '6':"Elevator", '7':"Rug", '8':"Erase",
-            '9':"StairUp", '0':"StairDown"
+            '5':"Hole", '6':"Door", '7':"StairUp", '8':"StairDown", '9':"Erase"
         }
         if codepoint in mapping:
             self._select_tool(mapping[codepoint]); return True
-        if codepoint in ('v','V'):
-            self._select_tool("Vent"); return True
-        if codepoint in ('p','P'):
-            self._select_tool("Plant"); return True
-        if codepoint in ('d','D'):
-            self._select_tool("Desk"); return True
-        if codepoint in ('o','O'):
-            self._select_tool("Chair"); return True
-        if codepoint in ('t','T'):
-            self._select_tool("Table"); return True
         return False
 
     def _find_levels(self):
@@ -573,6 +595,11 @@ class LevelEditorRoot(FloatLayout):
         if ok:
             self.current_file = text
         self.canvas_view.status.text = f"{'Loaded' if ok else 'No file found'}: {text}"
+
+    def _on_scenery_select(self, spinner, text):
+        if text == "Scenery":
+            return
+        self._select_tool(text)
 
     def _on_color_select(self, spinner, text):
         self.canvas_view.door_color = text


### PR DESCRIPTION
## Summary
- Add scenery dropdown in editor toolbar to group decoration tools
- Support new scenery items: big colored buttons and blue screen monitor
- Render new decorations and treat them as collidable in-game

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa1933e3883298fd32dda3e5ea6f1