### PR TITLE
Enlarge door hacking progress bar

### DIFF
--- a/stealth_golf.py
+++ b/stealth_golf.py
@@ -821,9 +821,9 @@ class StealthGolf(Widget):
                 sx, sy, sw, sh = self.hacking_door["screen"]
                 pct = 1.0 - (self.hack_timer / HACK_DURATION)
                 Color(0.2, 0.8, 0.2, 1)
-                Rectangle(pos=(sx, sy + sh + 4), size=(sw * pct, 4))
+                Rectangle(pos=(sx, sy + sh + 4), size=(sw * pct, 12))
                 Color(1, 1, 1, 1)
-                Line(rectangle=(sx, sy + sh + 4, sw, 4), width=1)
+                Line(rectangle=(sx, sy + sh + 4, sw, 12), width=1)
             # Stairs
             for s in self.stairs:
                 rx, ry, rw, rh = s["rect"]


### PR DESCRIPTION
## Summary
- Triple the door-hacking progress bar height for better visibility
- Update progress bar outline to match new height

## Testing
- `pytest -q` *(fails: skipped due to missing Kivy dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d1913e6483299739e443f4ad36c9