### PR TITLE
Match door and screen colors

### DIFF
--- a/stealth_golf.py
+++ b/stealth_golf.py
@@ -819,7 +819,7 @@ class StealthGolf(Widget):
                 col = DOOR_COLORS.get(d.get("color", "red"), (0.7, 0.1, 0.1))
                 Color(col[0], col[1], col[2], self.floor_fade_t)
                 Rectangle(pos=(rx, ry), size=(rw, rh))
-                Color(0.1, 0.1, 0.1, self.floor_fade_t)
+                Color(col[0], col[1], col[2], self.floor_fade_t)
                 Rectangle(pos=(sx, sy), size=(sw, sh))
             if self.hacking_door and self.hack_timer > 0:
                 sx, sy, sw, sh = self.hacking_door["screen"]

--- a/stealth_golf_level_editor.py
+++ b/stealth_golf_level_editor.py
@@ -373,7 +373,7 @@ class LevelCanvas(Widget):
                 r,g,b = COLOR_MAP.get(d.get("color","red"), (0.8,0,0))
                 Color(r,g,b,1.0)
                 Rectangle(pos=(rx,ry), size=(rw,rh))
-                Color(1,1,1,0.2)
+                Color(r,g,b,0.3)
                 Rectangle(pos=(sx,sy), size=(sw,sh))
                 Color(1,1,1,0.8)
                 Line(rectangle=(sx,sy,sw,sh), width=1.1)


### PR DESCRIPTION
## Summary
- Render door screens in game using their door's color instead of a fixed grey, keeping the fade alpha.
- Tint door screens in the level editor to match each door's RGB with a translucent fill.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0e25254f083298006d24f4e1c06ec