### PR TITLE
Ensure base friction respects frame rate

### DIFF
--- a/stealth_golf.py
+++ b/stealth_golf.py
@@ -221,8 +221,11 @@ class Ball:
         if speed < 5:
             self.vx = self.vy = 0.0; self.in_motion = False
         else:
-            base_fric = 0.985
-            self.vx *= base_fric; self.vy *= base_fric
+            # Base friction factor expressed per 60 FPS frame.  Raise to
+            # ``dt * 60`` so damping remains consistent regardless of frame rate.
+            base_fric = 0.985  # per-frame at 60 FPS
+            fric = base_fric ** max(1.0, dt * 60.0)
+            self.vx *= fric; self.vy *= fric
 
             # Extra *low-speed damping*: quickly but smoothly bleed velocity
             if speed < LOW_SPEED_THRESHOLD:


### PR DESCRIPTION
## Summary
- Convert ball's base friction to a frame-rate independent factor using 60 FPS baseline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0e5117dcc8329a71cb780278a75b8