### PR TITLE
Add new decor objects and editor support

### DIFF
--- a/level_13.json
+++ b/level_13.json
@@ -32,7 +32,7 @@
       ],
       "decor": [
         {
-          "kind": "table",
+          "kind": "cardboard_box",
           "rect": [
             600,
             1440,

--- a/level_14.json
+++ b/level_14.json
@@ -32,7 +32,7 @@
       ],
       "decor": [
         {
-          "kind": "table",
+          "kind": "tesla_coil",
           "rect": [
             600,
             1520,

--- a/level_15.json
+++ b/level_15.json
@@ -32,7 +32,7 @@
       ],
       "decor": [
         {
-          "kind": "table",
+          "kind": "teleporter_pad",
           "rect": [
             600,
             1600,

--- a/level_16.json
+++ b/level_16.json
@@ -32,7 +32,7 @@
       ],
       "decor": [
         {
-          "kind": "table",
+          "kind": "robotic_arm",
           "rect": [
             600,
             1680,

--- a/level_17.json
+++ b/level_17.json
@@ -32,7 +32,7 @@
       ],
       "decor": [
         {
-          "kind": "table",
+          "kind": "metal_table",
           "rect": [
             600,
             1760,

--- a/level_18.json
+++ b/level_18.json
@@ -32,7 +32,7 @@
       ],
       "decor": [
         {
-          "kind": "table",
+          "kind": "golf_ball",
           "rect": [
             600,
             1840,

--- a/stealth_golf.py
+++ b/stealth_golf.py
@@ -586,7 +586,18 @@ class StealthGolf(Widget):
 
         # Decor
         self.decor = []
-        collidable = {"plant", "desk", "chair", "table"}
+        collidable = {
+            "plant",
+            "desk",
+            "chair",
+            "table",
+            "cardboard_box",
+            "tesla_coil",
+            "teleporter_pad",
+            "robotic_arm",
+            "metal_table",
+            "golf_ball",
+        }
         for d in f.get("decor", []):
             if isinstance(d, dict):
                 kind = d.get("kind", "")
@@ -889,6 +900,30 @@ class StealthGolf(Widget):
             elif kind == "table":
                 Color(0.4, 0.3, 0.2, alpha); Rectangle(pos=(rx, ry), size=(rw, rh))
                 Color(0.3, 0.22, 0.15, alpha); Line(rectangle=(rx, ry, rw, rh), width=1.2)
+            elif kind == "cardboard_box":
+                Color(0.7, 0.55, 0.3, alpha); Rectangle(pos=(rx, ry), size=(rw, rh))
+                Color(0.6, 0.45, 0.25, alpha)
+                Line(rectangle=(rx, ry, rw, rh), width=1)
+                Line(points=[rx + rw / 2, ry, rx + rw / 2, ry + rh], width=1)
+            elif kind == "tesla_coil":
+                Color(0.4, 0.4, 0.45, alpha); Rectangle(pos=(rx, ry), size=(rw, rh * 0.2))
+                Color(0.55, 0.3, 0.2, alpha); Rectangle(pos=(rx + rw * 0.4, ry + rh * 0.2), size=(rw * 0.2, rh * 0.5))
+                Color(0.8, 0.8, 0.85, alpha); Ellipse(pos=(rx, ry + rh * 0.7), size=(rw, rh * 0.3))
+            elif kind == "teleporter_pad":
+                Color(0.2, 0.2, 0.25, alpha); Ellipse(pos=(rx, ry), size=(rw, rh))
+                Color(0.0, 0.6, 0.9, alpha); Line(ellipse=(rx, ry, rw, rh), width=2)
+                Color(0.0, 0.8, 1.0, 0.5 * alpha); Ellipse(pos=(rx + rw * 0.2, ry + rh * 0.2), size=(rw * 0.6, rh * 0.6))
+            elif kind == "robotic_arm":
+                Color(0.3, 0.3, 0.35, alpha); Rectangle(pos=(rx, ry), size=(rw, rh * 0.2))
+                Color(0.6, 0.6, 0.62, alpha); Rectangle(pos=(rx + rw * 0.45, ry + rh * 0.2), size=(rw * 0.1, rh * 0.5))
+                Rectangle(pos=(rx + rw * 0.45, ry + rh * 0.7), size=(rw * 0.4, rh * 0.1))
+                Rectangle(pos=(rx + rw * 0.8, ry + rh * 0.7), size=(rw * 0.15, rh * 0.15))
+            elif kind == "metal_table":
+                Color(0.6, 0.6, 0.65, alpha); Rectangle(pos=(rx, ry), size=(rw, rh))
+                Color(0.45, 0.45, 0.5, alpha); Line(rectangle=(rx, ry, rw, rh), width=1.2)
+            elif kind == "golf_ball":
+                Color(0.95, 0.95, 0.95, alpha); Ellipse(pos=(rx, ry), size=(rw, rh))
+                Color(0.85, 0.85, 0.85, alpha); Line(ellipse=(rx, ry, rw, rh), width=1)
             else:
                 col = d.get("color", [0.3, 0.3, 0.35, 1])
                 if len(col) == 3:

--- a/stealth_golf_level_editor.py
+++ b/stealth_golf_level_editor.py
@@ -60,6 +60,12 @@ SCENERY_KIND_MAP = {
     "Chair": "chair",
     "Table": "table",
     "BlueScreen": "blue_screen_monitor",
+    "CardboardBox": "cardboard_box",
+    "TeslaCoil": "tesla_coil",
+    "TeleporterPad": "teleporter_pad",
+    "RoboticArm": "robotic_arm",
+    "MetalTable": "metal_table",
+    "GolfBall": "golf_ball",
 }
 SCENERY_TOOLS = tuple(SCENERY_KIND_MAP.keys())
 
@@ -341,6 +347,43 @@ class LevelCanvas(Widget):
                     Rectangle(pos=(rx,ry), size=(rw,rh))
                     Color(0.2,0.4,0.9,1.0)
                     Rectangle(pos=(rx+5, ry+5), size=(rw-10, rh-10))
+                elif kind == "cardboard_box":
+                    Color(0.7,0.55,0.3,1.0)
+                    Rectangle(pos=(rx,ry), size=(rw,rh))
+                    Color(0.6,0.45,0.25,1.0)
+                    Line(rectangle=(rx,ry,rw,rh), width=1)
+                    Line(points=[rx+rw/2, ry, rx+rw/2, ry+rh], width=1)
+                elif kind == "tesla_coil":
+                    Color(0.4,0.4,0.45,1.0)
+                    Rectangle(pos=(rx,ry), size=(rw, rh*0.2))
+                    Color(0.55,0.3,0.2,1.0)
+                    Rectangle(pos=(rx+rw*0.4, ry+rh*0.2), size=(rw*0.2, rh*0.5))
+                    Color(0.8,0.8,0.85,1.0)
+                    Ellipse(pos=(rx, ry+rh*0.7), size=(rw, rh*0.3))
+                elif kind == "teleporter_pad":
+                    Color(0.2,0.2,0.25,1.0)
+                    Ellipse(pos=(rx,ry), size=(rw,rh))
+                    Color(0.0,0.6,0.9,1.0)
+                    Line(ellipse=(rx,ry,rw,rh), width=2)
+                    Color(0.0,0.8,1.0,0.7)
+                    Ellipse(pos=(rx+rw*0.2, ry+rh*0.2), size=(rw*0.6, rh*0.6))
+                elif kind == "robotic_arm":
+                    Color(0.3,0.3,0.35,1.0)
+                    Rectangle(pos=(rx,ry), size=(rw, rh*0.2))
+                    Color(0.6,0.6,0.62,1.0)
+                    Rectangle(pos=(rx+rw*0.45, ry+rh*0.2), size=(rw*0.1, rh*0.5))
+                    Rectangle(pos=(rx+rw*0.45, ry+rh*0.7), size=(rw*0.4, rh*0.1))
+                    Rectangle(pos=(rx+rw*0.8, ry+rh*0.7), size=(rw*0.15, rh*0.15))
+                elif kind == "metal_table":
+                    Color(0.6,0.6,0.65,1.0)
+                    Rectangle(pos=(rx,ry), size=(rw,rh))
+                    Color(0.45,0.45,0.5,1.0)
+                    Line(rectangle=(rx,ry,rw,rh), width=1.2)
+                elif kind == "golf_ball":
+                    Color(0.95,0.95,0.95,1.0)
+                    Ellipse(pos=(rx,ry), size=(rw,rh))
+                    Color(0.85,0.85,0.85,1.0)
+                    Line(ellipse=(rx,ry,rw,rh), width=1)
 
             # Doors
             for d in self.doors:


### PR DESCRIPTION
## Summary
- render new decor kinds like cardboard boxes, tesla coils, teleporter pads, robotic arms, metal tables, and golf balls
- allow the level editor to place and display these new scenery kinds
- update later levels to use the new decor identifiers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2298e448083299b29bdfe38c22f04