### PR TITLE
Use SCENERY_TOOLS tuple for drag operations

### DIFF
--- a/stealth_golf_level_editor.py
+++ b/stealth_golf_level_editor.py
@@ -230,7 +230,7 @@ class LevelCanvas(Widget):
             self.cam_y = max(0, min(self.cam_y, self.world_h - self.height))
             return True
 
-        if self.tool in ("Wall","Elevator","Rug","Vent","Plant","Desk","Chair","Table","StairUp","StairDown","Door") and self.dragging and self.temp_rect:
+        if self.tool in ("Wall", "StairUp", "StairDown", "Door") + SCENERY_TOOLS and self.dragging and self.temp_rect:
             x0,y0,_,_ = self.temp_rect
             x1,y1 = wx, wy
             x = min(x0,x1); y = min(y0,y1)


### PR DESCRIPTION
## Summary
- Replace hard-coded tool list in `LevelCanvas.on_touch_move` with tuple including `SCENERY_TOOLS`.
- Enables rectangle dragging for any current or future scenery tool.

## Testing
- `pytest -q`
- Verified `CardboardBox` tool drag placement via scripted stub


------
https://chatgpt.com/codex/tasks/task_e_68a22c194f7c8329a0b007b506298c42