### PR TITLE
Add stroke counter and level star rating system

### DIFF
--- a/level.json
+++ b/level.json
@@ -14,6 +14,8 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
+
   "floors": [
     {
       "walls": [

--- a/level_10.json
+++ b/level_10.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [],

--- a/level_11.json
+++ b/level_11.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_12.json
+++ b/level_12.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_13.json
+++ b/level_13.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_14.json
+++ b/level_14.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_15.json
+++ b/level_15.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_16.json
+++ b/level_16.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_17.json
+++ b/level_17.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_18.json
+++ b/level_18.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_19.json
+++ b/level_19.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 1,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_2.json
+++ b/level_2.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_3.json
+++ b/level_3.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_4.json
+++ b/level_4.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_5.json
+++ b/level_5.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_6.json
+++ b/level_6.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_7.json
+++ b/level_7.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_8.json
+++ b/level_8.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/level_9.json
+++ b/level_9.json
@@ -14,6 +14,7 @@
     "r": 22
   },
   "hole_floor": 0,
+  "stars": {"three": 6, "two": 10, "one": 11},
   "floors": [
     {
       "walls": [

--- a/stealth_golf.py
+++ b/stealth_golf.py
@@ -499,6 +499,7 @@ class StealthGolf(Widget):
             self.level_index = 1
 
         self._apply_level_data(data)
+        self.score_box = None
 
         # Previous floor visuals and cross-fade progress
         self.prev_walls = []
@@ -540,6 +541,16 @@ class StealthGolf(Widget):
         hole = data.get("hole", {"cx": 1240, "cy": 2020, "r": 22})
         self.hole = (int(hole["cx"]), int(hole["cy"]), int(hole.get("r", 22)))
         self.hole_floor = int(data.get("hole_floor", 0))
+
+        # Stroke and star state
+        self.star_thresholds = data.get(
+            "stars", {"three": 6, "two": 10, "one": 11}
+        )
+        self.stroke_count = 0
+        self.star_count = 0
+        if hasattr(self, "score_box") and self.score_box:
+            self.remove_widget(self.score_box)
+            self.score_box = None
 
         if "floors" in data:
             self.floors = data["floors"]
@@ -669,6 +680,7 @@ class StealthGolf(Widget):
             "start_floor": 0,
             "hole": {"cx": 1240, "cy": 2020, "r": 22},
             "hole_floor": 0,
+            "stars": {"three": 6, "two": 10, "one": 11},
             "floors": [
                 {
                     "walls": [
@@ -702,7 +714,7 @@ class StealthGolf(Widget):
                 self.level_index = idx
                 self._apply_level_data(data)
                 # Reset state for new level
-                self.caught=False; self.win=False; self.message_timer=1.5
+                self.caught=False; self.win=False; self.message_timer=0.0
                 self.drop_timer=0.0
                 return True
         print("No further levels found up to", MAX_LEVEL_INDEX)
@@ -729,14 +741,12 @@ class StealthGolf(Widget):
 
     # ------------- Input -------------
     def on_touch_down(self, touch):
-        if self.caught or self.win:
-            if self.win and self.drop_timer <= 0:
-                # If win banner is shown after drop, try autoload next level
-                if not self._try_load_next_level():
-                    self._reset_to_start()
-            else:
-                self._reset_to_start()
+        if self.caught:
+            self._reset_to_start()
             return True
+        if self.win:
+            # Let score screen widgets handle the touch
+            return False
         wx, wy = self.screen_to_world(touch.x, touch.y)
         if length(wx - self.ball.x, wy - self.ball.y) <= self.ball.r + 36 and not self.ball.in_motion:
             self.aiming=True; self.aim_touch_id=touch.uid; self.aim_start=(wx,wy); self.aim_current=(wx,wy); return True
@@ -756,6 +766,7 @@ class StealthGolf(Widget):
                 ix, iy = normalize(ix, iy); ix*=self.max_shot; iy*=self.max_shot
             scale = 1.90
             self.ball.apply_impulse(ix*scale, iy*scale)
+            self.stroke_count += 1
             self.aiming=False; self.aim_touch_id=None; return True
         return False
 
@@ -821,8 +832,10 @@ class StealthGolf(Widget):
                     and not self.win
                     and length(self.ball.x - cx, self.ball.y - cy) <= (hr - 2)
                 ):
-                    self.win = True; self.drop_timer = 0.9; self.message_timer = 1.6
+                    self.win = True
                     self.ball.vx = self.ball.vy = 0.0; self.ball.in_motion = False
+                    self.star_count = self._compute_stars()
+                    self._show_score_screen()
                 # stairs
                 if not self.win and not self.caught:
                     currently_on_stairs = False
@@ -1052,13 +1065,19 @@ class StealthGolf(Widget):
         if not hasattr(self, "banner"):
             self.banner = Label(text="", font_size=20, color=(1,1,1,1), size_hint=(None,None), size=(self.width,40), pos=(10, self.height - 90))
             self.add_widget(self.banner)
+        if not hasattr(self, "stroke_label"):
+            self.stroke_label = Label(
+                text="Strokes: 0",
+                font_size=20,
+                color=(1, 1, 1, 1),
+                size_hint=(None, None),
+                size=(120, 40),
+                pos=(self.width - 130, self.height - 40),
+            )
+            self.add_widget(self.stroke_label)
+        self.stroke_label.text = f"Strokes: {self.stroke_count}"
         if self.caught and self.message_timer > 0:
             self.banner.text = "[b]Caught![/b] Tap to restart."; self.banner.markup=True
-            self.message_timer = max(0.0, self.message_timer - 1/60)
-        elif self.win and self.drop_timer > 0:
-            self.banner.text = "Dropping to next level..."; self.banner.markup=True
-        elif self.win and self.drop_timer <= 0 and self.message_timer > 0:
-            self.banner.text = "[b]Level complete![/b] • Loading next (if present)…"; self.banner.markup=True
             self.message_timer = max(0.0, self.message_timer - 1/60)
         else:
             self.banner.text = ""
@@ -1073,6 +1092,11 @@ class StealthGolf(Widget):
         self.ball.vx = self.ball.vy = 0.0
         self.ball.smoke_timer = 0.0
         self.caught = False; self.win=False; self.drop_timer=0.0; self.message_timer=0.0
+        self.stroke_count = 0
+        self.star_count = 0
+        if hasattr(self, "score_box") and self.score_box:
+            self.remove_widget(self.score_box)
+            self.score_box = None
         self.on_stairs = False
         self.hacking_door = None
         self.hack_timer = 0.0
@@ -1089,6 +1113,44 @@ class StealthGolf(Widget):
                     self.colliders.append(rect)
         for a in self.agents:
             a.x,a.y = a.ax,a.ay; a.dir=1; a.chasing=False; a.look_dirx, a.look_diry = normalize(a.bx-a.ax, a.by-a.ay)
+
+    def _compute_stars(self):
+        three = self.star_thresholds.get("three", 6)
+        two = self.star_thresholds.get("two", 10)
+        one = self.star_thresholds.get("one", 11)
+        if self.stroke_count <= three:
+            return 3
+        elif self.stroke_count <= two:
+            return 2
+        elif self.stroke_count >= one:
+            return 1
+        else:
+            return 0
+
+    def _show_score_screen(self):
+        stars_text = "★" * self.star_count + "☆" * (3 - self.star_count)
+        box = BoxLayout(
+            orientation="vertical",
+            padding=20,
+            spacing=20,
+            size_hint=(None, None),
+            size=(300, 200),
+            pos=(self.width / 2 - 150, self.height / 2 - 100),
+        )
+        label = Label(text=stars_text, font_size=48, color=(1, 1, 1, 1))
+        btn = Button(text="Next Level", size_hint=(1, None), height=50)
+        btn.bind(on_release=self._next_level)
+        box.add_widget(label)
+        box.add_widget(btn)
+        self.add_widget(box)
+        self.score_box = box
+
+    def _next_level(self, *args):
+        if hasattr(self, "score_box") and self.score_box:
+            self.remove_widget(self.score_box)
+            self.score_box = None
+        if not self._try_load_next_level():
+            self._next_level_banner()
 
 # ----------------------------- Screens & App ---------------------------------
 


### PR DESCRIPTION
## Summary
- Show current stroke count during play
- Rate performance with stars and display score screen after sinking the ball
- Enable per-level star thresholds for easy tuning

## Testing
- `pytest -q` *(skipped: No module named 'kivy')*
- `python -m py_compile stealth_golf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab757c98832995703eeab88d75f8